### PR TITLE
Refactor shuffle the array method

### DIFF
--- a/src/task/vector/shuffle.rs
+++ b/src/task/vector/shuffle.rs
@@ -1,9 +1,9 @@
 #[must_use]
 pub fn shuffle_the_array(nums: &[i32], n: usize) -> Vec<i32> {
-    let mut ans: Vec<i32> = Vec::with_capacity(2 * n);
-    for i in 0..n {
-        ans.push(nums[i]);
-        ans.push(nums[i + n]);
-    }
-    ans
+    let (arr_x, arr_y) = nums.split_at(n);
+    arr_x
+        .iter()
+        .zip(arr_y.iter())
+        .flat_map(|(&x, &y): (&i32, &i32)| [x, y])
+        .collect()
 }


### PR DESCRIPTION
## 관련 이슈

closes #57 

## PR 설명

`flat_map` 과 함께 `zip`, `split_at` 을 이용했습니다.
