### PR TITLE
Refactor sorting the sentence method

### DIFF
--- a/src/task/string/sorting.rs
+++ b/src/task/string/sorting.rs
@@ -1,20 +1,18 @@
 #[must_use]
 pub fn sorting_the_sentence(s: &str) -> String {
-    let mut words: Vec<(String, u32)> = s
+    let mut words: Vec<(&str, char)> = s
         .split_whitespace()
-        .map(|word| {
-            let c = word.chars().last();
-            let order = c.unwrap_or('0').to_digit(10).unwrap_or(0);
-            (word[..word.len() - 1].to_string(), order)
+        .filter_map(|word| {
+            let (text, last) = word.split_at(word.len() - 1);
+            last.chars().next().map(|c| (text, c))
         })
         .collect();
 
-    words.sort_by_key(|&(_, order)| order);
+    words.sort_unstable_by_key(|&(_, c)| c.to_digit(10).unwrap_or(0));
 
     words
         .into_iter()
-        .map(|(w, _)| w)
+        .map(|(w, _)| w.to_string())
         .collect::<Vec<String>>()
         .join(" ")
-        .to_string()
 }

--- a/src/task/string/sorting.rs
+++ b/src/task/string/sorting.rs
@@ -1,14 +1,17 @@
 #[must_use]
 pub fn sorting_the_sentence(s: &str) -> String {
-    let mut words: Vec<(&str, char)> = s
+    let mut words: Vec<(&str, u32)> = s
         .split_whitespace()
         .filter_map(|word| {
             let (text, last) = word.split_at(word.len() - 1);
-            last.chars().next().map(|c| (text, c))
+            match last.parse() {
+                Ok(id) => Some((text, id)),
+                Err(_) => None,
+            }
         })
         .collect();
 
-    words.sort_unstable_by_key(|&(_, c)| c.to_digit(10).unwrap_or(0));
+    words.sort_unstable_by_key(|&(_, idx)| idx);
 
     words
         .into_iter()

--- a/src/task/string/sorting.rs
+++ b/src/task/string/sorting.rs
@@ -15,7 +15,7 @@ pub fn sorting_the_sentence(s: &str) -> String {
 
     words
         .into_iter()
-        .map(|(w, _)| w.to_string())
-        .collect::<Vec<String>>()
+        .map(|(w, _)| w)
+        .collect::<Vec<_>>()
         .join(" ")
 }


### PR DESCRIPTION
## 관련 이슈

closes #64 

## PR 설명

`filter_map`, `sort_unstable_by_key`, `split_at` 을 이용하도록 수정했습니다.
또한, 반환 과정에서 불필요 했던 `to_string` 메서드를 제거했습니다.