### PR TITLE
Refactor shuffle string

### DIFF
--- a/src/task/en_de_coding/shuffle_string.rs
+++ b/src/task/en_de_coding/shuffle_string.rs
@@ -1,6 +1,6 @@
 #[must_use]
 pub fn shuffle_string(s: &str, indices: &[i32]) -> String {
     let mut sc: Vec<(usize, char)> = s.chars().enumerate().collect();
-    sc.sort_by_key(|(i, _)| indices[*i]);
-    sc.iter().map(|(_, c)| c.to_string()).collect::<String>()
+    sc.sort_unstable_by_key(|(i, _)| indices[*i]);
+    sc.iter().map(|(_, c)| c).collect::<String>()
 }


### PR DESCRIPTION
## 관련 이슈

closes #77 

## PR 설명

`to_string` 제거 및 `sort_unstable` 로 변경했습니다.
